### PR TITLE
Add payload deployed notification setting

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -59,6 +59,7 @@ model enabled_guilds {
   notification_go              Int?                     @default(0) @db.UnsignedTinyInt
   notification_liftoff         Int?                     @default(0) @db.UnsignedTinyInt
   notification_hold            Int?                     @default(0) @db.UnsignedTinyInt
+  notification_deploy          Int?                     @default(0) @db.UnsignedTinyInt
   notification_end_status      Int?                     @default(0) @db.UnsignedTinyInt
   notification_scheduled_event Int?                     @default(0) @db.UnsignedTinyInt
   notification_button_fc       Int?                     @default(1) @db.UnsignedTinyInt

--- a/src/app/(dashboard)/notifications/client.tsx
+++ b/src/app/(dashboard)/notifications/client.tsx
@@ -522,7 +522,7 @@ export default function Client({ guild, countdowns, channels }: ClientProps) {
 				<Setting
 					label={'Payload Deployed'}
 					description={
-						'Will the bot send a notification when the launch deploys its payload?'
+						'Will the bot send a notification when the payload deploys?'
 					}
 					active={settings.notification_deploy}
 					disabled={guild.notification_channel_id === null}

--- a/src/app/(dashboard)/notifications/client.tsx
+++ b/src/app/(dashboard)/notifications/client.tsx
@@ -51,6 +51,7 @@ export interface CountdownSetting {
 
 export interface NotificationsFilterSettings {
 	notification_end_status: boolean;
+	notification_deploy: boolean;
 	notification_hold: boolean;
 	notification_go: boolean;
 	notification_liftoff: boolean;
@@ -66,6 +67,7 @@ export default function Client({ guild, countdowns, channels }: ClientProps) {
 
 	const [settings, setSettings] = useState<NotificationsFilterSettings>({
 		notification_end_status: Boolean(guild.notification_end_status),
+		notification_deploy: Boolean(guild.notification_deploy),
 		notification_hold: Boolean(guild.notification_hold),
 		notification_liftoff: Boolean(guild.notification_liftoff),
 		notification_go: Boolean(guild.notification_go),
@@ -514,6 +516,32 @@ export default function Client({ guild, countdowns, channels }: ClientProps) {
 							}));
 						}}
 						defaultChecked={settings.notification_end_status}
+					/>
+				</Setting>
+
+				<Setting
+					label={'Payload Deployed'}
+					description={
+						'Will the bot send a notification when the launch deploys its payload?'
+					}
+					active={settings.notification_deploy}
+					disabled={guild.notification_channel_id === null}
+					disabledMessage={
+						'Requires a notification channel to be set'
+					}
+				>
+					<Switch
+						onCheckedChange={checked => {
+							updateFilters(String(guild.guild_id), {
+								...settings,
+								notification_deploy: checked,
+							});
+							setSettings(prev => ({
+								...prev,
+								notification_deploy: checked,
+							}));
+						}}
+						defaultChecked={settings.notification_deploy}
 					/>
 				</Setting>
 


### PR DESCRIPTION
Original issue #45 
Adding payload deployed bool to prisma schema and notification dashboard. Not yet tested.